### PR TITLE
AR-8-write-script-to-run-training-on-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Ignore Python bytecode files
+*.pyc
+
+# Ignore __pycache__ directories
+__pycache__/
+
+# Ignore cached files and folders in specific directories
+models/__pycache__/
+utils/__pycache__/
+utils/loggers/__pycache__/
+utils/loggers/clearml/__pycache__/
+utils/loggers/comet/__pycache__/
+utils/loggers/wandb/__pycache__/
+
+# Ignore runs directory
+runs/
+
+# Ignore python environment
+recyclingEnv/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ runs/
 
 # Ignore python environment
 .recyclingEnv/
+
+# Ignore generated yolov5s.pt
+yolov5s.pt

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ utils/loggers/wandb/__pycache__/
 runs/
 
 # Ignore python environment
-recyclingEnv/
+.recyclingEnv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gitpython>=3.1.30
 matplotlib>=3.3
 numpy>=1.22.2
 opencv-python>=4.1.1
-Pillow==10.0.1
+Pillow>=10.0.1
 psutil  # system resources
 PyYAML>=5.3.1
 requests>=2.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gitpython>=3.1.30
 matplotlib>=3.3
 numpy>=1.22.2
 opencv-python>=4.1.1
-Pillow>=10.0.1
+Pillow==10.0.1
 psutil  # system resources
 PyYAML>=5.3.1
 requests>=2.23.0

--- a/srun_test_script.sh
+++ b/srun_test_script.sh
@@ -2,9 +2,7 @@
 
 date >> ~/hpc-share/ai-recycling/log_srun.log
 
-srun -p gpu,dgx2,dgxh,share --gres=gpu:1 --mem=20g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
-# srun -p gpu,dgxh,share -t 4 --gres=gpu:1 --mem=10g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
-# srun ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
+srun -p gpu,dgxh --gres=gpu:1 --mem=20g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh &>> ~/hpc-share/ai-recycling/log_srun.log
 
 echo "──────────────────────────────────────────" >> ~/hpc-share/ai-recycling/log_srun.log
 echo >> ~/hpc-share/ai-recycling/log_srun.log

--- a/srun_test_script.sh
+++ b/srun_test_script.sh
@@ -1,6 +1,6 @@
 date >> ~/hpc-share/ai-recycling/log_srun.log
 
-srun -p gpu,dgxh --gres=gpu:1 --mem=20g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh &>> ~/hpc-share/ai-recycling/log_srun.log
+srun -p gpu,dgxh --gres=gpu:1 --mem=20g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh $@ &>> ~/hpc-share/ai-recycling/log_srun.log
 
 echo "──────────────────────────────────────────" >> ~/hpc-share/ai-recycling/log_srun.log
 echo >> ~/hpc-share/ai-recycling/log_srun.log

--- a/srun_test_script.sh
+++ b/srun_test_script.sh
@@ -1,0 +1,10 @@
+# cd ~/hpc-share/ai-recycling/ai-recycling/
+
+date >> ~/hpc-share/ai-recycling/log_srun.log
+
+srun -p gpu,dgx2,dgxh,share --gres=gpu:1 --mem=20g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
+# srun -p gpu,dgxh,share -t 4 --gres=gpu:1 --mem=10g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
+# srun ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
+
+echo "──────────────────────────────────────────" >> ~/hpc-share/ai-recycling/log_srun.log
+echo >> ~/hpc-share/ai-recycling/log_srun.log

--- a/srun_test_script.sh
+++ b/srun_test_script.sh
@@ -1,5 +1,3 @@
-# cd ~/hpc-share/ai-recycling/ai-recycling/
-
 date >> ~/hpc-share/ai-recycling/log_srun.log
 
 srun -p gpu,dgxh --gres=gpu:1 --mem=20g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/test_server_script.sh &>> ~/hpc-share/ai-recycling/log_srun.log

--- a/srun_train_script.sh
+++ b/srun_train_script.sh
@@ -1,5 +1,3 @@
-# cd ~/hpc-share/ai-recycling/ai-recycling/
-
 date >> ~/hpc-share/ai-recycling/log_srun.log
 
 srun -p gpu,dgxh --gres=gpu:1 --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/training_script.sh &>> ~/hpc-share/ai-recycling/log_srun.log

--- a/srun_train_script.sh
+++ b/srun_train_script.sh
@@ -2,9 +2,7 @@
 
 date >> ~/hpc-share/ai-recycling/log_srun.log
 
-srun -p gpu,dgxh --gres=gpu:1 --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/training_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
-#srun -p gpu,dgxh,dgx2 -t 4 --gres=gpu:1 --mem=10g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/training_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
-# srun ~/hpc-share/ai-recycling/ai-recycling/training_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
+srun -p gpu,dgxh --gres=gpu:1 --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/training_script.sh &>> ~/hpc-share/ai-recycling/log_srun.log
 
 echo "──────────────────────────────────────────" >> ~/hpc-share/ai-recycling/log_srun.log
 echo >> ~/hpc-share/ai-recycling/log_srun.log

--- a/srun_train_script.sh
+++ b/srun_train_script.sh
@@ -1,0 +1,10 @@
+# cd ~/hpc-share/ai-recycling/ai-recycling/
+
+date >> ~/hpc-share/ai-recycling/log_srun.log
+
+srun -p gpu,dgxh --gres=gpu:1 --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/training_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
+#srun -p gpu,dgxh,dgx2 -t 4 --gres=gpu:1 --mem=10g --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/training_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
+# srun ~/hpc-share/ai-recycling/ai-recycling/training_script.sh >> ~/hpc-share/ai-recycling/log_srun.log 2>> ~/hpc-share/ai-recycling/log_srun.log
+
+echo "──────────────────────────────────────────" >> ~/hpc-share/ai-recycling/log_srun.log
+echo >> ~/hpc-share/ai-recycling/log_srun.log

--- a/srun_train_script.sh
+++ b/srun_train_script.sh
@@ -1,6 +1,6 @@
 date >> ~/hpc-share/ai-recycling/log_srun.log
 
-srun -p gpu,dgxh --gres=gpu:1 --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/training_script.sh &>> ~/hpc-share/ai-recycling/log_srun.log
+srun -p gpu,dgxh --gres=gpu:1 --time=1-00:00:00 --pty ~/hpc-share/ai-recycling/ai-recycling/training_script.sh $@ &>> ~/hpc-share/ai-recycling/log_srun.log
 
 echo "──────────────────────────────────────────" >> ~/hpc-share/ai-recycling/log_srun.log
 echo >> ~/hpc-share/ai-recycling/log_srun.log

--- a/test_server_script.sh
+++ b/test_server_script.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#SBATCH -J recycling        # name of my job
+#SBATCH -p gpu,dgxh,dgx2    # name of partition/queue to use
+#SBATCH -o recycling.out    # name of output file for batch script
+#SBATCH -e recycling.err    # name of error file for batch script
+#SBATCH -c 1                # number of cores per task
+#SBATCH -t 4                # number of threads per task
+#SBATCH --time=1-00:00:00   # time needed for job
+#SBATCH --mem=10g           # memory needed for job
+#SBATCH --gres=gpu:1        # consumable resources needed for job
+#SBATCH --mem=10g           # memory needed for job
+
+cd ~/hpc-share/ai-recycling/ai-recycling
+# gather basic information, can be useful for troubleshooting
+hostname
+echo $SLURM_JOBID
+showjob $SLURM_JOBID
+
+# load modules needed for job
+module load slurm
+module restore recycling_module
+# virtualenv --no-download ~/$SLURM_TMPDIR/env
+# source ~/$SLURM_TMPDIR/env/bin/activate
+# pip install --no-index --upgrade pip
+
+# Load/update environment
+source ./recyclingEnv/bin/activate
+
+# Test new env
+# deactivate
+# rm -r testEnv
+# python3 -m venv testEnv
+# source ./testEnv/bin/activate
+
+# ERROR: No matching distribution found for gitpython>=3.1.30
+pip3 install -q -r ./requirements.txt
+# pip3 install keyboard
+# pip3 install supervision
+# pip install --no-index -r requirements.txt
+
+# Debug
+# module list
+# pip3 list
+# python3 -V
+
+# run my job
+date
+echo "Running ai-recycling from bash shell"
+echo
+
+# Run test server
+file="output_$(date +"%Y_%m_%d_%I_%M_%p").log"
+python3 test_server.py ../recycle_small_test_slow.mp4 --hpc > "../$file"
+
+# Copy new files to austin's server
+scp "../$file" austin:~/outputs
+
+date

--- a/test_server_script.sh
+++ b/test_server_script.sh
@@ -33,7 +33,7 @@ echo
 
 # Run test server
 file="output_$(date +"%Y_%m_%d_%I_%M_%p").log"
-python3 test_server.py ../recycle_small_test_slow.mp4 --hpc &> "../$file"
+python3 test_server.py ../recycle_small_test_slow.mp4 --hpc $@ &> "../$file"
 
 # Copy new files to austin's server
 scp "../$file" austin:~/outputs

--- a/test_server_script.sh
+++ b/test_server_script.sh
@@ -11,6 +11,7 @@
 #SBATCH --mem=10g           # memory needed for job
 
 cd ~/hpc-share/ai-recycling/ai-recycling
+
 # gather basic information, can be useful for troubleshooting
 hostname
 echo $SLURM_JOBID
@@ -19,27 +20,11 @@ showjob $SLURM_JOBID
 # load modules needed for job
 module load slurm
 module restore recycling_module
-# virtualenv --no-download ~/$SLURM_TMPDIR/env
-# source ~/$SLURM_TMPDIR/env/bin/activate
-# pip install --no-index --upgrade pip
 
 # Load/update environment
 source ./.recyclingEnv/bin/activate
-
-# Test new env
-# deactivate
-# rm -r testEnv
-# python3 -m venv testEnv
-# source ./testEnv/bin/activate
-
-# ERROR: No matching distribution found for gitpython>=3.1.30
 #python3 -m pip install --upgrade pip
 pip3 install -q -r ./requirements.txt
-
-# Debug
-# module list
-# pip3 list
-# python3 -V
 
 # run my job
 date

--- a/test_server_script.sh
+++ b/test_server_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH -J recycling        # name of my job
-#SBATCH -p gpu,dgxh,dgx2    # name of partition/queue to use
+#SBATCH -p gpu,dgxh         # name of partition/queue to use
 #SBATCH -o recycling.out    # name of output file for batch script
 #SBATCH -e recycling.err    # name of error file for batch script
 #SBATCH -c 1                # number of cores per task
@@ -24,7 +24,7 @@ module restore recycling_module
 # pip install --no-index --upgrade pip
 
 # Load/update environment
-source ./recyclingEnv/bin/activate
+source ./.recyclingEnv/bin/activate
 
 # Test new env
 # deactivate
@@ -33,10 +33,8 @@ source ./recyclingEnv/bin/activate
 # source ./testEnv/bin/activate
 
 # ERROR: No matching distribution found for gitpython>=3.1.30
+#python3 -m pip install --upgrade pip
 pip3 install -q -r ./requirements.txt
-# pip3 install keyboard
-# pip3 install supervision
-# pip install --no-index -r requirements.txt
 
 # Debug
 # module list
@@ -50,7 +48,7 @@ echo
 
 # Run test server
 file="output_$(date +"%Y_%m_%d_%I_%M_%p").log"
-python3 test_server.py ../recycle_small_test_slow.mp4 --hpc > "../$file"
+python3 test_server.py ../recycle_small_test_slow.mp4 --hpc &> "../$file"
 
 # Copy new files to austin's server
 scp "../$file" austin:~/outputs

--- a/training_script.sh
+++ b/training_script.sh
@@ -10,6 +10,8 @@
 #SBATCH --gres=gpu:1        # consumable resources needed for job
 #SBATCH --mem=10g           # memory needed for job
 
+cd ~/hpc-share/ai-recycling/ai-recycling
+
 # gather basic information, can be useful for troubleshooting
 hostname
 echo $SLURM_JOBID
@@ -18,21 +20,16 @@ showjob $SLURM_JOBID
 # load modules needed for job
 module load slurm
 module restore recycling_module
-# module list
 
 # run my job
 date
 echo "Running ai-recycling from bash shell"
 echo
 
-cd ~/hpc-share/ai-recycling/ai-recycling
-
 # Load/update environment
 source ./.recyclingEnv/bin/activate
-# ERROR: No matching distribution found for gitpython>=3.1.30
 #python3 -m pip install --upgrade pip
 pip install -q -r ./requirements.txt
-# pip install --force-reinstall pillow
 
 # Run training
 file="output_$(date +"%Y_%m_%d_%I_%M_%p").log"

--- a/training_script.sh
+++ b/training_script.sh
@@ -33,7 +33,7 @@ pip install -q -r ./requirements.txt
 
 # Run training
 file="output_$(date +"%Y_%m_%d_%I_%M_%p").log"
-python3 train.py &> "../$file"
+python3 train.py $@ &> "../$file"
 
 # Copy new files to austin's server
 rsync -a --ignore-existing ~/hpc-share/ai-recycling/ai-recycling/runs/train/* austin:~/outputs

--- a/training_script.sh
+++ b/training_script.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#SBATCH -J recycling        # name of my job
+#SBATCH -p gpu,dgxh    # name of partition/queue to use
+#SBATCH -o recycling.out    # name of output file for batch script
+#SBATCH -e recycling.err    # name of error file for batch script
+#SBATCH -c 1                # number of cores per task
+#SBATCH -t 0                # number of threads per task
+#SBATCH --time=1-00:00:00   # time needed for job
+#SBATCH --mem=10g           # memory needed for job
+#SBATCH --gres=gpu:1        # consumable resources needed for job
+#SBATCH --mem=10g           # memory needed for job
+
+# gather basic information, can be useful for troubleshooting
+hostname
+echo $SLURM_JOBID
+showjob $SLURM_JOBID
+
+# load modules needed for job
+module load slurm
+module restore recycling_module
+# module list
+
+# run my job
+date
+echo "Running ai-recycling from bash shell"
+echo
+
+cd ~/hpc-share/ai-recycling/ai-recycling
+
+# Load/update environment
+source ./recyclingEnv/bin/activate
+# ERROR: No matching distribution found for gitpython>=3.1.30
+# pip install -q -r ./requirements.txt
+# pip install --force-reinstall pillow
+
+# Run training
+file="output_$(date +"%Y_%m_%d_%I_%M_%p").log"
+python3 train.py > "../$file"
+
+# Copy new files to austin's server
+rsync -a --ignore-existing ~/hpc-share/ai-recycling/ai-recycling/runs/train/* austin:~/outputs
+scp "../$file" austin:~/outputs
+
+date

--- a/training_script.sh
+++ b/training_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH -J recycling        # name of my job
-#SBATCH -p gpu,dgxh    # name of partition/queue to use
+#SBATCH -p gpu,dgxh         # name of partition/queue to use
 #SBATCH -o recycling.out    # name of output file for batch script
 #SBATCH -e recycling.err    # name of error file for batch script
 #SBATCH -c 1                # number of cores per task
@@ -28,14 +28,15 @@ echo
 cd ~/hpc-share/ai-recycling/ai-recycling
 
 # Load/update environment
-source ./recyclingEnv/bin/activate
+source ./.recyclingEnv/bin/activate
 # ERROR: No matching distribution found for gitpython>=3.1.30
-# pip install -q -r ./requirements.txt
+#python3 -m pip install --upgrade pip
+pip install -q -r ./requirements.txt
 # pip install --force-reinstall pillow
 
 # Run training
 file="output_$(date +"%Y_%m_%d_%I_%M_%p").log"
-python3 train.py > "../$file"
+python3 train.py &> "../$file"
 
 # Copy new files to austin's server
 rsync -a --ignore-existing ~/hpc-share/ai-recycling/ai-recycling/runs/train/* austin:~/outputs

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -127,6 +127,7 @@ class Annotator:
         self.lw = line_width or max(round(sum(im.shape) / 2 * 0.003), 2)  # line width
     
     def box_label(self, box,c, label='', color=(128, 128, 128), txt_color=(255, 255, 255), debug_save=False, obj_cls = None):
+        coord = coordinates_extraction(self, box, obj_cls)
               
         # Add one xyxy box to image with label
         if self.pil or not is_ascii(label):
@@ -143,7 +144,6 @@ class Annotator:
                 # self.draw.text((box[0], box[1]), label, fill=txt_color, font=self.font, anchor='ls')  # for PIL>8.0
                 self.draw.text((box[0], box[1] - h if outside else box[1]), label, fill=txt_color, font=self.font)
         else:  # cv2
-            coord = coordinates_extraction(self, box, obj_cls)
             # if debug_save:
             p1, p2 = (int(box[0]), int(box[1])), (int(box[2]), int(box[3]))
             cv2.rectangle(self.im, p1, p2, color, thickness=self.lw, lineType=cv2.LINE_AA)


### PR DESCRIPTION
implemented scripts/modifications for HPC runs, how to use: 
on Austin's machine: **./ssh_hpc [test_server/train/clear] \<additional arguments for python script\>**
e.g.: **./ssh_hpc.sh train --epoch 5**

This will run the corresponding scripts on the HPC submit server to create nodes and run the corresponding python scripts

issue still exists:
```
Exception in thread Thread-11:
Traceback (most recent call last):
  File "/usr/lib64/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "/nfs/hpc/share/keel/ai-recycling/ai-recycling/utils/plots.py", line 342, in plot_images
    annotator.box_label(box, label, color=color)
  File "/nfs/hpc/share/keel/ai-recycling/ai-recycling/utils/plots.py", line 130, in box_label
    coord = coordinates_extraction(self, box, obj_cls)
  File "/nfs/hpc/share/keel/ai-recycling/ai-recycling/utils/plots.py", line 97, in coordinates_extraction
    roi = self.im[y1:y2, x1:x2]
TypeError: 'Image' object is not subscriptable
```